### PR TITLE
GitHub Action's Ubuntu no longer starts MySQL Server automatically

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
           bundle install --jobs 4 --retry 3
       - name: setup db
         run: |
+          sudo service mysql start
           cp config/database.yml.ci config/database.yml
           bundle exec rake db:setup
       - name: test


### PR DESCRIPTION
https://github.blog/changelog/2020-02-21-github-actions-breaking-change-ubuntu-virtual-environments-will-no-longer-start-the-mysql-service-automatically/