### PR TITLE
Update gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,17 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.0.3.1)
-      activesupport (= 6.0.3.1)
-    activerecord (6.0.3.1)
-      activemodel (= 6.0.3.1)
-      activesupport (= 6.0.3.1)
+    activemodel (6.0.3.2)
+      activesupport (= 6.0.3.2)
+    activerecord (6.0.3.2)
+      activemodel (= 6.0.3.2)
+      activesupport (= 6.0.3.2)
     activerecord-quiet_schema_version (0.2.0)
       activerecord
     activerecord-simple_index_name (1.0.0)
       activerecord (>= 5.0.0)
       activesupport (>= 5.0.0)
-    activesupport (6.0.3.1)
+    activesupport (6.0.3.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -22,14 +22,14 @@ GEM
       activesupport (>= 4.2, < 7.0)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    backports (3.17.2)
+    backports (3.18.1)
     bundler-audit (0.7.0.1)
       bundler (>= 1.2.0, < 3)
       thor (>= 0.18, < 2)
     concurrent-ruby (1.1.6)
     connection_pool (2.2.3)
     database_rewinder (0.9.4)
-    diff-lcs (1.3)
+    diff-lcs (1.4.3)
     et-orbi (1.2.4)
       tzinfo
     faraday (1.0.1)
@@ -69,7 +69,7 @@ GEM
       omniauth (~> 1.9)
     public_suffix (4.0.5)
     raabro (1.3.1)
-    rack (2.2.2)
+    rack (2.2.3)
     rack-protection (2.0.8.1)
       rack
     rack-test (1.1.0)
@@ -124,7 +124,7 @@ GEM
     tilt (2.0.10)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
-    zeitwerk (2.3.0)
+    zeitwerk (2.3.1)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
It still depends on redis < 4.2.
sidekiq v6.1.0 has been released, but sidekiq-cron is not yet.