### PR TITLE
Use redis:6.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
   redis:
-    image: "redis:5.0-alpine"
+    image: "redis:6.0-alpine"
     ports:
       - "6379:6379"
     volumes:


### PR DESCRIPTION
Amazon ElastiCache for Redis already supports Redis v6.0.
https://aws.amazon.com/blogs/aws/new-redis-6-compatibility-for-amazon-elasticache/