### PR TITLE
Remove `version` from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   mysql:
     image: "mysql:8.0"


### PR DESCRIPTION
`version` property is optional since v1.27.0