### PR TITLE
Update gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,9 +24,7 @@ gem "sinatra-contrib"
 gem "sinatra-flash", require: ["sinatra/flash"]
 
 group :test do
-  # https://github.com/amatsuda/database_rewinder/pull/74
-  # https://github.com/amatsuda/database_rewinder/pull/77
-  gem "database_rewinder", github: "r7kamura/database_rewinder", branch: "feature/rails-6-1"
+  gem "database_rewinder"
   gem "rack-test"
   gem "rspec", group: :development
   gem "rspec-request_describer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,30 +1,23 @@
-GIT
-  remote: https://github.com/r7kamura/database_rewinder
-  revision: 5900cb505ae7c4cb545185a60517e0c5c0fa5809
-  branch: feature/rails-6-1
-  specs:
-    database_rewinder (0.9.4)
-
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.3.1)
-      activesupport (= 6.1.3.1)
-    activerecord (6.1.3.1)
-      activemodel (= 6.1.3.1)
-      activesupport (= 6.1.3.1)
+    activemodel (6.1.3.2)
+      activesupport (= 6.1.3.2)
+    activerecord (6.1.3.2)
+      activemodel (= 6.1.3.2)
+      activesupport (= 6.1.3.2)
     activerecord-quiet_schema_version (0.2.0)
       activerecord
     activerecord-simple_index_name (1.0.0)
       activerecord (>= 5.0.0)
       activesupport (>= 5.0.0)
-    activesupport (6.1.3.1)
+    activesupport (6.1.3.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    acts_as_paranoid (0.7.2)
+    acts_as_paranoid (0.7.3)
       activerecord (>= 5.2, < 7.0)
       activesupport (>= 5.2, < 7.0)
     addressable (2.7.0)
@@ -34,15 +27,20 @@ GEM
       thor (~> 1.0)
     concurrent-ruby (1.1.8)
     connection_pool (2.2.5)
+    database_rewinder (0.9.5)
     diff-lcs (1.4.4)
     et-orbi (1.2.4)
       tzinfo
-    faraday (1.4.1)
+    faraday (1.4.2)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
       faraday-net_http (~> 1.0)
       faraday-net_http_persistent (~> 1.1)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.1.0)
@@ -67,7 +65,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    octokit (4.20.0)
+    octokit (4.21.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     omniauth (2.0.4)
@@ -120,7 +118,7 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.1.0)
       tilt (~> 2.0)
-    sinatra-activerecord (2.0.22)
+    sinatra-activerecord (2.0.23)
       activerecord (>= 4.1)
       sinatra (>= 1.0)
     sinatra-contrib (2.1.0)
@@ -148,7 +146,7 @@ DEPENDENCIES
   activerecord-simple_index_name
   acts_as_paranoid
   bundler-audit
-  database_rewinder!
+  database_rewinder
   gemnasium-parser
   i18n
   mysql2


### PR DESCRIPTION
```
Gem                   Current        Latest   Requested  Groups
activemodel           6.1.3.1        6.1.3.2
activerecord          6.1.3.1        6.1.3.2  >= 0       default
activesupport         6.1.3.1        6.1.3.2
acts_as_paranoid      0.7.2          0.7.3    >= 0       default
database_rewinder     0.9.4 5900cb5  0.9.5    >= 0       test
faraday               1.4.1          1.4.2
octokit               4.20.0         4.21.0   >= 0       default
sinatra-activerecord  2.0.22         2.0.23   >= 0       default
```
